### PR TITLE
compatibility with recent cubical

### DIFF
--- a/1FundamentalGroup/Preambles/P0.agda
+++ b/1FundamentalGroup/Preambles/P0.agda
@@ -2,7 +2,7 @@ module 1FundamentalGroup.Preambles.P0 where
 
 open import Cubical.Data.Empty using (⊥) public
 open import Cubical.Data.Unit renaming ( Unit to ⊤ ) public
-open import Cubical.Data.Bool public
+open import Cubical.Data.Bool hiding (elim) public
 open import Cubical.Foundations.Prelude
      renaming ( subst to endPt
               ; transport to pathToFun


### PR DESCRIPTION
Without this commit, there is a naming collision with the `elim` of Cubical.HITs.S1.

This issue was brought to my attention by an Agdapad player :-)

Thank you for your work on the HoTT game :-)