### PR TITLE
Update for cubical 0.9

### DIFF
--- a/0Trinitarianism/Preambles/P0.agda
+++ b/0Trinitarianism/Preambles/P0.agda
@@ -1,3 +1,3 @@
 module 0Trinitarianism.Preambles.P0 where
 
-open import Cubical.Core.Everything hiding (_∨_) public
+open import Cubical.Foundations.Prelude hiding (_∨_) public

--- a/0Trinitarianism/Preambles/P1.agda
+++ b/0Trinitarianism/Preambles/P1.agda
@@ -1,6 +1,6 @@
 module 0Trinitarianism.Preambles.P1 where
 
-open import Cubical.Core.Everything public
+open import Cubical.Foundations.Prelude public
 open import Cubical.Data.Unit public renaming (Unit to ⊤)
 open import Cubical.Data.Empty public using (⊥)
 open import Cubical.Data.Nat public hiding (isEven)

--- a/0Trinitarianism/Preambles/P2.agda
+++ b/0Trinitarianism/Preambles/P2.agda
@@ -1,6 +1,6 @@
 module 0Trinitarianism.Preambles.P2 where
 
-open import Cubical.Core.Everything public
+open import Cubical.Foundations.Prelude public
 open import Cubical.Data.Unit public renaming (Unit to ⊤)
 open import Cubical.Data.Empty public using (⊥)
 open import Cubical.Data.Nat public hiding (isEven)

--- a/0Trinitarianism/Preambles/P3.agda
+++ b/0Trinitarianism/Preambles/P3.agda
@@ -1,6 +1,6 @@
 module 0Trinitarianism.Preambles.P3 where
 
-open import Cubical.Core.Everything public
+open import Cubical.Foundations.Prelude public
 open import Cubical.Data.Nat public hiding (_+_ ; isEven)
 open import 0Trinitarianism.Quest1Solutions public
 open import Cubical.Data.Empty public using (⊥)

--- a/0Trinitarianism/Preambles/P5.agda
+++ b/0Trinitarianism/Preambles/P5.agda
@@ -3,12 +3,11 @@ module 0Trinitarianism.Preambles.P5 where
 open import Cubical.Foundations.Prelude renaming
   (funExt to libFunExt ;
    sym to libSym ;
-   _≡⟨_⟩_ to lib_≡⟨_⟩_ ;
    _∎ to lib_∎ ;
    _∙_ to lib_∙_ ;
    fst to libFst ;
    snd to libSnd
-  ) public
+  ) hiding ( step-≡ ) public
 open import Cubical.HITs.S1 using ( S¹ ; base ; loop ) public
 open import Cubical.Foundations.Isomorphism renaming (Iso to _≅_) public
 open import Cubical.Foundations.Path public
@@ -32,6 +31,3 @@ PathPIsoPathD {u} {A} {B} p x =
   subst (λ b → (y : B) → (PathP (λ i → p i) x y) ≅ (b ≡ y))
     (sym (pathToFun≡transport p x))
     (PathPIsoPath _ x)
-
-
-

--- a/1FundamentalGroup/Preambles/P0.agda
+++ b/1FundamentalGroup/Preambles/P0.agda
@@ -2,11 +2,11 @@ module 1FundamentalGroup.Preambles.P0 where
 
 open import Cubical.Data.Empty using (⊥) public
 open import Cubical.Data.Unit renaming ( Unit to ⊤ ) public
-open import Cubical.Data.Bool hiding (elim) public
+open import Cubical.Data.Bool renaming ( elim to Bool-elim ) public
 open import Cubical.Foundations.Prelude
      renaming ( subst to endPt
               ; transport to pathToFun
               ) public
 open import Cubical.Foundations.Isomorphism renaming ( Iso to _≅_ ) public
 open import Cubical.Foundations.Path public
-open import Cubical.HITs.S1 public
+open import Cubical.HITs.S1 renaming ( elim to S¹-elim ) public

--- a/TheHoTTGame.agda-lib
+++ b/TheHoTTGame.agda-lib
@@ -1,4 +1,7 @@
 name: TheHoTTGame
 include: .
 depend: cubical
-flags: --cubical --no-import-sorts
+flags:
+  --cubical
+  --no-import-sorts
+  -W noUnsupportedIndexedMatch

--- a/TheHoTTGame.agda-lib
+++ b/TheHoTTGame.agda-lib
@@ -3,5 +3,7 @@ include: .
 depend: cubical
 flags:
   --cubical
+  --guardedness
   --no-import-sorts
   -W noUnsupportedIndexedMatch
+  --allow-unsolved-metas

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ba90d4ee66469dced4f2de1749d41e3551558934",
-        "sha256": "0r4rnikvbl8ispj31ag728bb30ajj0sbw7fmax81q52wlcabl73r",
+        "rev": "e2605be20a68d8d72e6879c8b0522ee16fad0acf",
+        "sha256": "07qvqr91fsa3a6fniggm8s7fcklfhkxk86c8czvrv842rfch08vv",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/ba90d4ee66469dced4f2de1749d41e3551558934.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/e2605be20a68d8d72e6879c8b0522ee16fad0acf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "5830a4dd348d77e39a0f3c4c762ff2663b602d4c",
-        "sha256": "1d3lsrqvci4qz2hwjrcnd8h5vfkg8aypq3sjd4g3izbc8frwz5sm",
+        "rev": "dd678782cae74508d6b4824580d2b0935308011e",
+        "sha256": "0dk8dhh9vla2s409anmrfkva6h3r32xmz3cm8ha09wyk8iyf1f87",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/5830a4dd348d77e39a0f3c4c762ff2663b602d4c.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/dd678782cae74508d6b4824580d2b0935308011e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f0f67400bc49c44f305d6fe17698a2f1ce1c29a0",
-        "sha256": "0ilw6j8xj0p3mn0rcqa5ps3ncvr49g8n4rd2hp6jizlwdrd3w6jk",
+        "rev": "7b6929d8b900de3142638310f8bc40cff4f2c507",
+        "sha256": "00fywq8jksw9fyfzvmd3lanm9lc9j66z6bkxadjn63kdr1d16zab",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/f0f67400bc49c44f305d6fe17698a2f1ce1c29a0.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/7b6929d8b900de3142638310f8bc40cff4f2c507.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Replaces https://github.com/thehottgame/TheHoTTGame/pull/17. Also works with cubical 0.8 and probably older versions.

Updates the Nix dependencies to Agda 2.7.0.1 and cubical 0.8.

See also https://github.com/thehottgame/theHoTTGameGuide/pull/24